### PR TITLE
subsys: ctr_ble: Fix incorrect bt_conn_unref in disconnected callback

### DIFF
--- a/subsys/ctr_ble/ctr_ble.c
+++ b/subsys/ctr_ble/ctr_ble.c
@@ -227,7 +227,12 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 #endif
 	}
 
-	bt_conn_unref(conn);
+	/* NOTE: Do NOT call bt_conn_unref(conn) on the callback parameter!
+	 * The conn pointer passed to disconnected callback is managed by the
+	 * Zephyr BLE stack, which will unref it after all callbacks return.
+	 * See zephyr/subsys/bluetooth/host/conn.c:2248-2253 (deferred_work).
+	 * Only unref connections that YOUR code explicitly ref'd (like m_current_conn).
+	 */
 
 	check_and_erase_bonds();
 }


### PR DESCRIPTION
Remove incorrect bt_conn_unref(conn) call in the disconnected callback that was causing BLE connection reference counting imbalances.

Problem:
- When attempting to reconnect to the same BLE device, bt_conn_le_create() would fail with error -22 (EINVAL)
- Connection objects would linger for 5+ seconds after disconnection
- bt_conn_exists_le() would report 'Found valid connection in disconnected state'

Root Cause:
- The conn parameter passed to the disconnected callback is managed by the Zephyr BLE stack, which automatically unreferences it AFTER all callbacks return (see zephyr/subsys/bluetooth/host/conn.c:2248-2253 in deferred_work)
- Calling bt_conn_unref(conn) on the callback parameter creates a reference counting imbalance, preventing proper cleanup
- This bug was introduced in commit 1115192 (Sep 29, 2024) when adding BLE client (central role) support

Solution:
- Remove the incorrect bt_conn_unref(conn) call
- Add explanatory comments about proper reference counting
- Applications should only unref connections they explicitly ref'd (like m_current_conn in the peripheral role handler)

Impact:
- Fixes reconnection failures when connecting to the same device multiple times
- Reduces connection cleanup time from 5+ seconds to <1 second typically
- Resolves reference counting imbalances that could affect dual-role BLE apps

Testing:
- Verified with Chester application using concurrent central/peripheral roles
- Tested reconnection to same BLE device multiple times in quick succession
- Confirmed connection cleanup completes within expected timeframe