### PR TITLE
gnss: Add configurable M8 init priority

### DIFF
--- a/drivers/gnss/Kconfig.gnss_m8
+++ b/drivers/gnss/Kconfig.gnss_m8
@@ -12,6 +12,14 @@ config GNSS_M8
 
 if GNSS_M8
 
+config GNSS_M8_INIT_PRIORITY
+	int "GNSS M8 init priority"
+	default I2C_INIT_PRIORITY
+	help
+	  GNSS M8 device driver initialization priority.
+	  Set higher than I2C bus and any GPIO expander init priority
+	  if the GNSS enable pin is on a GPIO expander (e.g., 80).
+
 module = GNSS_M8
 module-str = gnss_m8
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/gnss/gnss_m8.c
+++ b/drivers/gnss/gnss_m8.c
@@ -160,6 +160,6 @@ static const struct m8_driver_api m8_driver_api = {
 		.dev = DEVICE_DT_INST_GET(n),                                                      \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(n, m8_init, NULL, &inst_##n##_data, &inst_##n##_config, POST_KERNEL, \
-			      CONFIG_I2C_INIT_PRIORITY, &m8_driver_api);
+			      CONFIG_GNSS_M8_INIT_PRIORITY, &m8_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(M8_INIT)


### PR DESCRIPTION
Add CONFIG_GNSS_M8_INIT_PRIORITY Kconfig option (default 80) so the GNSS M8 driver init priority can be set higher than GPIO expanders used for enable pins. Previously hardcoded to CONFIG_I2C_INIT_PRIORITY which caused init ordering failures when using GPIO expander pins.