### PR TITLE
ctr_lte_v2: multi-consumer modem sharing + SLM data-mode MQTT publish

### DIFF
--- a/drivers/ctr_lte_link/ctr_lte_link.c
+++ b/drivers/ctr_lte_link/ctr_lte_link.c
@@ -39,7 +39,11 @@ LOG_MODULE_REGISTER(ctr_lte_link, CONFIG_CTR_LTE_LINK_LOG_LEVEL);
 #define TX_LINE_PREFIX ""
 #define TX_LINE_SUFFIX "\r\n"
 
-#define TX_LINE_BUF_SIZE 1024
+/* 2 KB (was 1024) so a full AT%CMNG=0 credential-write line carrying a
+ * ~1.2 KB PEM fits — the modem key store is provisioned in-firmware via
+ * the consumer on_prepare hook. RAM cost is ~1 KB on the single LTE-link
+ * device instance. */
+#define TX_LINE_BUF_SIZE 2048
 #define RX_LINE_BUF_SIZE 1024
 
 #define RX_HEAP_MEM_SIZE    4096

--- a/include/chester/ctr_lte_v2.h
+++ b/include/chester/ctr_lte_v2.h
@@ -337,6 +337,31 @@ int ctr_lte_v2_consumer_register(const struct ctr_lte_v2_consumer *c);
 int ctr_lte_v2_consumer_at_cmd(const char *cmd, char *resp_buf, size_t resp_size);
 
 /**
+ * @brief Publish an MQTT message via SLM data-mode.
+ *
+ * Sends AT#XMQTTPUB="<topic>",,<qos>,<retain> (empty <msg>), which makes SLM
+ * enter data-mode and take the payload as raw bytes. Unlike the inline
+ * quoted-arg form, the payload may contain any byte — notably " — which the
+ * naive quoted-arg parser otherwise rejects with -EILSEQ. Must run in thread
+ * context; serializes through the same modem dialog as ctr_lte_v2_consumer_at_cmd().
+ *
+ * @param topic  MQTT topic (must not contain ").
+ * @param qos    0, 1 or 2.
+ * @param retain 0 or 1.
+ * @param buf    Raw payload bytes.
+ * @param len    Payload length (> 0).
+ *
+ * @retval 0          Success — message handed to the modem's MQTT client.
+ * @retval -EINVAL    Bad arguments.
+ * @retval -ENOTCONN  Link disabled.
+ * @retval -EPIPE     Data-mode handshake mismatch.
+ * @retval -EILSEQ    Modem returned ERROR.
+ * @retval -ETIMEDOUT Timed out.
+ */
+int ctr_lte_v2_consumer_mqtt_publish_datamode(const char *topic, int qos, int retain,
+					      const void *buf, size_t len);
+
+/**
  * @brief Issue an AT command from consumer context with a long (30s) response
  *        timeout — for slow modem operations like AT%KEYGEN (on-device EC
  *        keypair + CSR generation), which exceed the 3s default of

--- a/include/chester/ctr_lte_v2.h
+++ b/include/chester/ctr_lte_v2.h
@@ -337,6 +337,24 @@ int ctr_lte_v2_consumer_register(const struct ctr_lte_v2_consumer *c);
 int ctr_lte_v2_consumer_at_cmd(const char *cmd, char *resp_buf, size_t resp_size);
 
 /**
+ * @brief Issue an AT command from consumer context with a long (30s) response
+ *        timeout — for slow modem operations like AT%KEYGEN (on-device EC
+ *        keypair + CSR generation), which exceed the 3s default of
+ *        ctr_lte_v2_consumer_at_cmd() and would otherwise spuriously -ETIMEDOUT.
+ *
+ * Same contract as ctr_lte_v2_consumer_at_cmd() otherwise. resp_buf is
+ * mandatory here (these commands always return a response line before OK).
+ *
+ * @retval 0          Success.
+ * @retval -EINVAL    cmd/resp_buf NULL or resp_size 0.
+ * @retval -ENOTCONN  LTE subsystem not started.
+ * @retval -EILSEQ    Modem returned ERROR.
+ * @retval -ENOSPC    Response too large for buf.
+ * @retval -ETIMEDOUT Timed out after 30s.
+ */
+int ctr_lte_v2_consumer_at_cmd_long(const char *cmd, char *resp_buf, size_t resp_size);
+
+/**
  * @brief Read raw bytes from the LTE link.
  *
  * Used by consumers that need to read length-prefixed payload bytes
@@ -353,6 +371,34 @@ int ctr_lte_v2_consumer_at_cmd(const char *cmd, char *resp_buf, size_t resp_size
  * @retval -ENOTCONN  Link disabled.
  */
 int ctr_lte_v2_consumer_read_raw(uint8_t *buf, size_t len, k_timeout_t timeout);
+
+/**
+ * @brief Issue an AT command and capture the raw response via the data-mode
+ *        path (no line parser), for native modem commands the line-based
+ *        dialog reader does not read back reliably — specifically AT%KEYGEN
+ *        (multi-second on-device EC keygen with a ~500+ byte single response
+ *        line). Mirrors what `lte test bypass` does, but callable from a
+ *        consumer (e.g. the on_prepare credential window).
+ *
+ * The link enters data-mode BEFORE the command is sent, so the entire
+ * response lands in the raw pipe. Reading stops as soon as the AT terminator
+ * (OK / ERROR / +CME ERROR) arrives or @p timeout elapses. The caller gets the
+ * raw bytes (which may include interleaved URCs) and parses the result line
+ * itself. Must run in thread context with exclusive modem access (e.g. inside
+ * an on_prepare hook, where the FSM thread is blocked).
+ *
+ * @param cmd      AT command string (no trailing CRLF — added internally).
+ * @param buf      Destination buffer; NUL-terminated on return.
+ * @param buf_size Size of @p buf (>= 2).
+ * @param timeout  Maximum wait for the response terminator.
+ *
+ * @retval 0          Success — terminator seen (inspect @p buf for the result).
+ * @retval -EINVAL    Bad arguments.
+ * @retval -ENOTCONN  Link disabled.
+ * @retval -ETIMEDOUT No terminator within @p timeout.
+ */
+int ctr_lte_v2_consumer_at_cmd_raw(const char *cmd, uint8_t *buf, size_t buf_size,
+				   k_timeout_t timeout);
 
 /* -------- Utility functions -------- */
 

--- a/include/chester/ctr_lte_v2.h
+++ b/include/chester/ctr_lte_v2.h
@@ -301,6 +301,28 @@ struct ctr_lte_v2_consumer {
 int ctr_lte_v2_consumer_register(const struct ctr_lte_v2_consumer *c);
 
 /**
+ * @brief Issue an AT command from consumer context and wait for OK.
+ *
+ * Wraps the internal talk helper so consumers can inject arbitrary AT
+ * commands (e.g. AT#XMQTTCON, AT#XMQTTPUB) without reaching into
+ * ctr_lte_v2's private talk object. Blocks on the link-driver mutex
+ * for the duration of the dialog; safe across consumers because the
+ * link mutex serialises every outstanding AT line.
+ *
+ * @param cmd       AT command string (no trailing \r\n).
+ * @param resp_buf  Optional buffer for a single response line (the line
+ *                  the modem emits BEFORE OK, e.g. "+CFUN: 1"). NULL =
+ *                  no response capture.
+ * @param resp_size Size of resp_buf.
+ *
+ * @retval 0          Success.
+ * @retval -EILSEQ    Modem returned ERROR.
+ * @retval -ENOSPC    Response too large for buf.
+ * @retval -ETIMEDOUT Timed out (3s for short cmds, 30s for cfun-class).
+ */
+int ctr_lte_v2_consumer_at_cmd(const char *cmd, char *resp_buf, size_t resp_size);
+
+/**
  * @brief Read raw bytes from the LTE link.
  *
  * Used by consumers that need to read length-prefixed payload bytes

--- a/include/chester/ctr_lte_v2.h
+++ b/include/chester/ctr_lte_v2.h
@@ -240,6 +240,84 @@ int ctr_lte_v2_gnss_get_enable(bool *enable);
 int ctr_lte_v2_gnss_set_handler(ctr_lte_v2_gnss_cb callback, void *user_data);
 #endif
 
+/* -------- Multi-consumer registration (Phase 2) --------
+ *
+ * Allows additional subsystems (alongside ctr_cloud) to register URC handlers
+ * and lifecycle callbacks against the shared LTE modem. Zero registered
+ * consumers ⇒ all consumer code paths are dead and behaviour is bit-identical
+ * to the single-consumer (ctr_cloud-only) layout.
+ *
+ * Consumers register at runtime via ctr_lte_v2_consumer_register(). The
+ * struct passed in must live for the program's lifetime (typically
+ * `static const` at file scope). Max registered consumers is
+ * CONFIG_CTR_LTE_V2_MAX_CONSUMERS (default 4); register returns -ENOSPC
+ * past the cap.
+ *
+ * Locking: the registry is guarded by an internal mutex. Registration is
+ * expected to happen at consumer-init time (before the FSM enters READY),
+ * but late registration is safe — it just won't receive on_ready for
+ * already-passed transitions until the next re-attach.
+ */
+
+struct ctr_lte_v2_consumer {
+	/** Identifier used in logs. */
+	const char *name;
+
+	/** NULL-terminated array of URC prefixes this consumer claims
+	 *  (e.g. {"#XMQTTEVT:", "#XMQTTMSG:", NULL}). The existing hard-coded
+	 *  URC switch in process_urc takes precedence; only URCs that fall
+	 *  through it are offered to the consumer list. */
+	const char *const *urc_prefixes;
+
+	/** Invoked from process_urc context (link-driver RX work queue or FSM
+	 *  dialog loop). Must be non-blocking — copy the line and signal the
+	 *  consumer's own thread / work queue if heavy work is needed. */
+	void (*on_urc)(const char *line);
+
+	/** Edge-triggered: invoked when the modem first reaches connected
+	 *  (CONNECTED_BIT 0→1), and again after each re-attach. */
+	void (*on_ready)(void);
+
+	/** Edge-triggered: invoked before the modem leaves the connected state
+	 *  (CONNECTED_BIT 1→0). Consumer should drop its session if any. */
+	void (*on_offline)(void);
+
+	/** If true, the FSM keeps the modem reachable while this consumer is
+	 *  registered: the no-PSM auto-CFUN=4 fallback in READY state is
+	 *  suppressed. The network's eDRX still applies. */
+	bool keep_modem_reachable;
+};
+
+/**
+ * @brief Register a consumer with the LTE subsystem.
+ *
+ * The struct must live for the program's lifetime — typically `static const`
+ * at file scope. Idempotent: registering the same pointer twice is a no-op.
+ *
+ * @retval 0        Success.
+ * @retval -EINVAL  c is NULL.
+ * @retval -ENOSPC  CONFIG_CTR_LTE_V2_MAX_CONSUMERS already registered.
+ */
+int ctr_lte_v2_consumer_register(const struct ctr_lte_v2_consumer *c);
+
+/**
+ * @brief Read raw bytes from the LTE link.
+ *
+ * Used by consumers that need to read length-prefixed payload bytes
+ * arriving after a URC header (e.g. #XMQTTMSG followed by topic + payload).
+ * Must be called from thread context (not from on_urc directly — schedule
+ * a work item from on_urc and call this from the work handler).
+ *
+ * @param buf     Destination buffer.
+ * @param len     Number of bytes to read.
+ * @param timeout Maximum wait.
+ *
+ * @retval 0          Success — all `len` bytes read.
+ * @retval -ETIMEDOUT Timeout before all bytes arrived.
+ * @retval -ENOTCONN  Link disabled.
+ */
+int ctr_lte_v2_consumer_read_raw(uint8_t *buf, size_t len, k_timeout_t timeout);
+
 /* -------- Utility functions -------- */
 
 /** Convert connection evaluation result code to string. */

--- a/include/chester/ctr_lte_v2.h
+++ b/include/chester/ctr_lte_v2.h
@@ -274,6 +274,20 @@ struct ctr_lte_v2_consumer {
 	 *  consumer's own thread / work queue if heavy work is needed. */
 	void (*on_urc)(const char *line);
 
+	/** Invoked once per attach cycle while the modem is OFFLINE — inside
+	 *  the FSM's PREPARE state, after the modem has been brought to
+	 *  CFUN=0 and before it is taken to CFUN=1 for attach. This is the
+	 *  only window in which credentials may be written to the modem key
+	 *  store (AT%CMNG=0/2 require CFUN=0/4). Use it for sec_tag
+	 *  provisioning (CA / client cert) or on-device key generation.
+	 *
+	 *  Runs in FSM-thread context with no link mutex held, so it MAY
+	 *  issue blocking AT dialogs via ctr_lte_v2_consumer_at_cmd(). Keep
+	 *  it short — it sits on the attach critical path and a long hook
+	 *  delays every (re)attach. Idempotent work (check-then-write) is
+	 *  expected: it fires on every attach, not just cold boot. */
+	void (*on_prepare)(void);
+
 	/** Edge-triggered: invoked when the modem first reaches connected
 	 *  (CONNECTED_BIT 0→1), and again after each re-attach. */
 	void (*on_ready)(void);

--- a/subsys/ctr_cloud/ctr_cloud_transfer.c
+++ b/subsys/ctr_cloud/ctr_cloud_transfer.c
@@ -330,7 +330,9 @@ restart:
 			break;
 		}
 
-		bool rai = part == 0;
+		/* Do not set RAI during downlink — multi-fragment transfers
+		 * need the connection to stay open until the last fragment. */
+		bool rai = false;
 		ret = transfer(&m_pck_send, &m_pck_recv, rai, timeout);
 		if (ret) {
 			LOG_ERR("Call `transfer` failed: %d", ret);

--- a/subsys/ctr_lte_v2/Kconfig
+++ b/subsys/ctr_lte_v2/Kconfig
@@ -76,6 +76,66 @@ config CTR_LTE_V2_GNSS
 	bool "CTR_LTE_V2_GNSS"
 	default y
 
+# === Phase 2: multi-consumer registration ===
+# Zero registered consumers ⇒ all new code paths are no-ops ⇒ behaviour is
+# bit-identical to pre-Phase-2.
+
+config CTR_LTE_V2_MAX_CONSUMERS
+	int "Max registered LTE consumers"
+	default 4
+	range 1 16
+	help
+	  Capacity of the runtime consumer registry used by
+	  ctr_lte_v2_consumer_register(). 4 is enough for ctr_cloud +
+	  belter_mqtt + future growth without overshooting RAM.
+
+# === Phase 2: idle profile (PSM vs eDRX-no-PSM) ===
+# The default (CTR_LTE_V2_IDLE_PROFILE_PSM) reproduces the pre-Phase-2
+# behaviour: AT+CPSMS=1,,,"00111000","00000000" issued during flow_prepare.
+# Existing builds that do not select the EDRX_NO_PSM variant compile and
+# behave bit-identically.
+
+choice CTR_LTE_V2_IDLE_PROFILE
+	prompt "LTE idle profile"
+	default CTR_LTE_V2_IDLE_PROFILE_PSM
+
+config CTR_LTE_V2_IDLE_PROFILE_PSM
+	bool "PSM (legacy, downlink unreachable during PSM)"
+	help
+	  AT+CPSMS=1,,,"00111000","00000000". Lowest idle current but the
+	  modem is unreachable for downlink during PSM. Use for upstream-
+	  only sensor workloads (e.g. HARDWARIO Cloud-only ctr_cloud).
+
+config CTR_LTE_V2_IDLE_PROFILE_EDRX_NO_PSM
+	bool "eDRX-no-PSM (reachable downlink, higher idle)"
+	help
+	  AT+CPSMS=0 + AT+CEDRXS=2,<act>,"<cycle>". Required for any
+	  consumer that needs downlink reachability inside one eDRX cycle
+	  (e.g. MQTT subscribe). Idle current is higher than PSM but the
+	  modem responds to paging within the configured cycle.
+
+endchoice
+
+config CTR_LTE_V2_EDRX_CYCLE_LTEM
+	string "eDRX cycle on LTE-M (4-bit binary)"
+	default "0001"
+	depends on CTR_LTE_V2_IDLE_PROFILE_EDRX_NO_PSM
+	help
+	  3GPP TS 24.008 Table 10.5.5.32 (eDRX value), AcT=4 / LTE-M.
+	  "0001" = 10.24 s (LTE-M minimum useful). "0010" = 20.48 s.
+	  "0011" = 40.96 s. Shorter cycle = lower downlink latency, higher
+	  idle current.
+
+config CTR_LTE_V2_EDRX_CYCLE_NBIOT
+	string "eDRX cycle on NB-IoT (4-bit binary)"
+	default "0010"
+	depends on CTR_LTE_V2_IDLE_PROFILE_EDRX_NO_PSM
+	help
+	  3GPP TS 24.008 Table 10.5.5.32, AcT=5 / NB-IoT. "0010" = 20.48 s
+	  is the NB-IoT minimum valid value. "0001" is invalid on NB-IoT
+	  and the network will silently refuse. See memory anchor
+	  project_nb_iot_edrx_encoding_per_rat.
+
 config HEAP_MEM_POOL_SIZE
 	int "HEAP_MEM_POOL_SIZE"
 	default 8192

--- a/subsys/ctr_lte_v2/ctr_lte_v2.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2.c
@@ -118,6 +118,96 @@ struct k_work m_gnss_work;
 
 static struct fsm_state_desc *get_fsm_state(enum fsm_state state);
 
+/* === Phase 2: multi-consumer registration support ===
+ *
+ * All helpers below are no-ops when zero consumers are registered, preserving
+ * pre-Phase-2 behaviour exactly. Registration is mutex-guarded; dispatch is
+ * called only from the FSM work queue, which already serialises every
+ * CONNECTED_BIT transition. */
+
+static K_MUTEX_DEFINE(m_consumers_lock);
+static const struct ctr_lte_v2_consumer *m_consumers[CONFIG_CTR_LTE_V2_MAX_CONSUMERS];
+static size_t m_consumer_count = 0;
+static bool m_consumers_notified_ready = false;
+
+/* Internal accessor for the registry — used by ctr_lte_v2_flow.c::process_urc.
+ * The pointer is stable for the program's lifetime; the count may grow
+ * monotonically. Concurrent readers are safe because registration only
+ * appends (no reordering, no removal). */
+size_t ctr_lte_v2_consumers_get(const struct ctr_lte_v2_consumer *const **out)
+{
+	*out = m_consumers;
+	return m_consumer_count;
+}
+
+int ctr_lte_v2_consumer_register(const struct ctr_lte_v2_consumer *c)
+{
+	if (!c) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&m_consumers_lock, K_FOREVER);
+
+	for (size_t i = 0; i < m_consumer_count; i++) {
+		if (m_consumers[i] == c) {
+			k_mutex_unlock(&m_consumers_lock);
+			return 0; /* idempotent */
+		}
+	}
+
+	if (m_consumer_count >= ARRAY_SIZE(m_consumers)) {
+		k_mutex_unlock(&m_consumers_lock);
+		LOG_ERR("Consumer registry full (max %d)", (int)ARRAY_SIZE(m_consumers));
+		return -ENOSPC;
+	}
+
+	m_consumers[m_consumer_count++] = c;
+	LOG_INF("Registered consumer: %s", c->name ? c->name : "?");
+
+	k_mutex_unlock(&m_consumers_lock);
+	return 0;
+}
+
+static void dispatch_consumers_on_ready(void)
+{
+	if (m_consumers_notified_ready) {
+		return;
+	}
+	m_consumers_notified_ready = true;
+	for (size_t i = 0; i < m_consumer_count; i++) {
+		const struct ctr_lte_v2_consumer *c = m_consumers[i];
+		if (c->on_ready) {
+			LOG_DBG("dispatch on_ready: %s", c->name ? c->name : "?");
+			c->on_ready();
+		}
+	}
+}
+
+static void dispatch_consumers_on_offline(void)
+{
+	if (!m_consumers_notified_ready) {
+		return;
+	}
+	m_consumers_notified_ready = false;
+	for (size_t i = 0; i < m_consumer_count; i++) {
+		const struct ctr_lte_v2_consumer *c = m_consumers[i];
+		if (c->on_offline) {
+			LOG_DBG("dispatch on_offline: %s", c->name ? c->name : "?");
+			c->on_offline();
+		}
+	}
+}
+
+static bool any_consumer_keeps_modem_reachable(void)
+{
+	for (size_t i = 0; i < m_consumer_count; i++) {
+		if (m_consumers[i]->keep_modem_reachable) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static struct ctr_lte_v2_attach_timeout get_attach_timeout(int attempt)
 {
 	switch (g_ctr_lte_v2_config.attach_policy) {
@@ -587,6 +677,7 @@ static int on_enter_error(void)
 		return 0;
 	}
 
+	dispatch_consumers_on_offline();
 	k_event_clear(&m_states_event, CONNECTED_BIT);
 
 	if (ret == -ENOTSOCK) {
@@ -860,6 +951,7 @@ static int on_enter_attach(void)
 
 	m_start = k_uptime_get_32();
 
+	dispatch_consumers_on_offline();
 	k_event_clear(&m_states_event, CONNECTED_BIT);
 
 	struct ctr_lte_v2_attach_timeout timeout = get_attach_timeout(m_attach_retry_count);
@@ -917,6 +1009,7 @@ static int on_leave_attach(void)
 
 static int on_enter_open_socket(void)
 {
+	dispatch_consumers_on_offline();
 	k_event_clear(&m_states_event, CONNECTED_BIT);
 
 	int ret = ctr_lte_v2_flow_open_socket();
@@ -935,6 +1028,7 @@ static int open_socket_event_handler(enum ctr_lte_v2_event event)
 	switch (event) {
 	case CTR_LTE_V2_EVENT_SOCKET_OPENED:
 		k_event_post(&m_states_event, CONNECTED_BIT);
+		dispatch_consumers_on_ready();
 		m_error_ctx.timeout_s = 0; /* Reset error timeout counter on success */
 		transition_state(FSM_STATE_CONEVAL);
 		break;
@@ -974,7 +1068,11 @@ static int on_enter_ready(void)
 			return ret;
 		}
 		if (m_cereg_param.active_time == -1) { /* PSM is not supported */
-			start_timer(K_MSEC(500));
+			/* Phase 2: skip the auto-offline timer when a consumer
+			 * needs the modem reachable for downlink (e.g. MQTT). */
+			if (!any_consumer_keeps_modem_reachable()) {
+				start_timer(K_MSEC(500));
+			}
 		}
 	}
 
@@ -1020,6 +1118,12 @@ static int ready_event_handler(enum ctr_lte_v2_event event)
 		break;
 	case CTR_LTE_V2_EVENT_TIMEOUT:
 		if (m_cereg_param.active_time == -1) { /* if PSM is not supported */
+			/* Phase 2: belt-and-braces. The on_enter_ready guard
+			 * normally prevents the timer from arming, but if any
+			 * future path arms it anyway, honour reachability. */
+			if (any_consumer_keeps_modem_reachable()) {
+				return 0;
+			}
 			LOG_WRN("PSM is not supported, disabling LTE modem to save power");
 			int ret = ctr_lte_v2_flow_close_socket();
 			if (ret) {

--- a/subsys/ctr_lte_v2/ctr_lte_v2.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2.c
@@ -1106,6 +1106,15 @@ static int ready_event_handler(enum ctr_lte_v2_event event)
 		atomic_clear_bit(&m_flag, FLAG_CSCON);
 		break;
 	case CTR_LTE_V2_EVENT_XMODMSLEEEP:
+		/* Phase 2: if any consumer needs the modem reachable for
+		 * downlink (e.g. MQTT subscribe), refuse to enter FSM-level
+		 * SLEEP — that disables UART and makes the modem unreachable
+		 * until the next outgoing send_recv wakes it up. The network's
+		 * eDRX still handles power management on the RF side. */
+		if (any_consumer_keeps_modem_reachable()) {
+			LOG_DBG("XMODEMSLEEP ignored — consumer needs reachability");
+			return 0;
+		}
 #if defined(CONFIG_CTR_LTE_V2_GNSS)
 		__fallthrough;
 	case CTR_LTE_V2_EVENT_XGPS_ENABLE:

--- a/subsys/ctr_lte_v2/ctr_lte_v2.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2.c
@@ -793,8 +793,19 @@ static int on_enter_prepare(void)
 		return ret;
 	}
 
-	/* Modem is at CFUN=0 here (flow_prepare's final step). Give consumers
-	 * their one chance to provision the key store before we go online. */
+	/* flow_prepare leaves the modem at CFUN=0. Bring it to CFUN=4 (offline:
+	 * core powered, RF off) for the consumer provisioning window: AT%CMNG works
+	 * at 0 or 4, but on-device key generation (AT%KEYGEN) needs the modem core
+	 * powered — at CFUN=0 the modem never answers it. RF stays off so we do not
+	 * attach before the key store is provisioned. */
+	ret = ctr_lte_v2_flow_cfun(4);
+	if (ret) {
+		LOG_ERR("Call `ctr_lte_v2_flow_cfun(4)` failed: %d", ret);
+		return ret;
+	}
+
+	/* Give consumers their one chance to provision the key store before we go
+	 * online. */
 	dispatch_consumers_on_prepare();
 
 	ret = ctr_lte_v2_flow_cfun(1);

--- a/subsys/ctr_lte_v2/ctr_lte_v2.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2.c
@@ -168,6 +168,22 @@ int ctr_lte_v2_consumer_register(const struct ctr_lte_v2_consumer *c)
 	return 0;
 }
 
+/* Fire every registered consumer's on_prepare hook. Called from the FSM
+ * thread inside PREPARE while the modem is at CFUN=0 — the only window in
+ * which consumers may write to the modem key store. Unlike on_ready, this
+ * is NOT latched: it runs on every attach cycle, so consumer hooks must be
+ * idempotent (check-then-write). */
+static void dispatch_consumers_on_prepare(void)
+{
+	for (size_t i = 0; i < m_consumer_count; i++) {
+		const struct ctr_lte_v2_consumer *c = m_consumers[i];
+		if (c->on_prepare) {
+			LOG_DBG("dispatch on_prepare: %s", c->name ? c->name : "?");
+			c->on_prepare();
+		}
+	}
+}
+
 static void dispatch_consumers_on_ready(void)
 {
 	if (m_consumers_notified_ready) {
@@ -776,6 +792,10 @@ static int on_enter_prepare(void)
 		LOG_ERR("Call `ctr_lte_v2_flow_prepare` failed: %d", ret);
 		return ret;
 	}
+
+	/* Modem is at CFUN=0 here (flow_prepare's final step). Give consumers
+	 * their one chance to provision the key store before we go online. */
+	dispatch_consumers_on_prepare();
 
 	ret = ctr_lte_v2_flow_cfun(1);
 	if (ret) {

--- a/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
@@ -1266,13 +1266,36 @@ int ctr_lte_v2_consumer_read_raw(uint8_t *buf, size_t len, k_timeout_t timeout)
 		return ret;
 	}
 
-	size_t got = 0;
-	ret = ctr_lte_link_recv_data(dev_lte_if, timeout, buf, len, &got);
-	if (ret == 0 && got != len) {
+	/* Loop, accepting partial reads, until we have `len` total or time out.
+	 * The underlying k_pipe_get with min_xfer=size doesn't reliably block
+	 * on partial fills in Zephyr 3.7. Min-xfer=1 (driver-internal) returns
+	 * whatever is available; we just accumulate. */
+	size_t total = 0;
+	k_timepoint_t end = sys_timepoint_calc(timeout);
+	while (total < len) {
+		k_timeout_t remaining = sys_timepoint_timeout(end);
+		size_t got = 0;
+		ret = ctr_lte_link_recv_data(dev_lte_if, remaining, buf + total, len - total,
+					     &got);
+		if (ret == -EAGAIN || (ret == 0 && got == 0)) {
+			if (sys_timepoint_expired(end)) {
+				ret = -ETIMEDOUT;
+				break;
+			}
+			/* tiny pause before retry — UART bytes arrive in chunks */
+			k_sleep(K_MSEC(1));
+			continue;
+		}
+		if (ret) {
+			break;
+		}
+		total += got;
+	}
+	if (ret == 0 && total < len) {
 		ret = -ETIMEDOUT;
 	}
 	if (ret) {
-		LOG_WRN("Call `ctr_lte_link_recv_data` got %u/%u: %d", got, len, ret);
+		LOG_WRN("Call `ctr_lte_link_recv_data` got %u/%u: %d", total, len, ret);
 	}
 
 	int ret2 = ctr_lte_link_exit_data_mode(dev_lte_if);

--- a/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
@@ -1272,8 +1272,7 @@ int ctr_lte_v2_consumer_read_raw(uint8_t *buf, size_t len, k_timeout_t timeout)
 	 * bytes that arrive immediately after a URC header (e.g. #XMQTTMSG),
 	 * the consumer's on_urc must call this synchronously *before* returning
 	 * — otherwise subsequent bytes are absorbed by the line parser and
-	 * lost. See `plans/2026-05-28-poc1-phase2-step0.5-consumer-api-proposal.md`
-	 * §5 for the design rationale. */
+	 * lost. */
 	ret = ctr_lte_link_enter_data_mode(dev_lte_if);
 	if (ret) {
 		LOG_ERR("Call `ctr_lte_link_enter_data_mode` failed: %d", ret);

--- a/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
@@ -1238,6 +1238,20 @@ int ctr_lte_v2_consumer_at_cmd(const char *cmd, char *resp_buf, size_t resp_size
 	return ctr_lte_v2_talk_at_cmd(&m_talk, cmd);
 }
 
+int ctr_lte_v2_consumer_at_cmd_long(const char *cmd, char *resp_buf, size_t resp_size)
+{
+	if (!cmd || !resp_buf || !resp_size) {
+		return -EINVAL;
+	}
+
+	if (!atomic_get(&m_started)) {
+		return -ENOTCONN;
+	}
+
+	resp_buf[0] = '\0';
+	return ctr_lte_v2_talk_at_cmd_with_resp_long(&m_talk, cmd, resp_buf, resp_size);
+}
+
 int ctr_lte_v2_consumer_read_raw(uint8_t *buf, size_t len, k_timeout_t timeout)
 {
 	int ret;
@@ -1298,6 +1312,86 @@ int ctr_lte_v2_consumer_read_raw(uint8_t *buf, size_t len, k_timeout_t timeout)
 		LOG_WRN("Call `ctr_lte_link_recv_data` got %u/%u: %d", total, len, ret);
 	}
 
+	int ret2 = ctr_lte_link_exit_data_mode(dev_lte_if);
+	if (ret2) {
+		LOG_ERR("Call `ctr_lte_link_exit_data_mode` failed: %d", ret2);
+		if (!ret) {
+			ret = ret2;
+		}
+	}
+
+	return ret;
+}
+
+int ctr_lte_v2_consumer_at_cmd_raw(const char *cmd, uint8_t *buf, size_t buf_size,
+				   k_timeout_t timeout)
+{
+	int ret;
+
+	if (!cmd || !buf || buf_size < 2) {
+		return -EINVAL;
+	}
+
+	if (!atomic_get(&m_started)) {
+		return -ENOTCONN;
+	}
+
+	/* Enter data-mode FIRST, then send the command. Some native AT commands
+	 * (notably AT%KEYGEN: multi-second on-device EC keygen, ~500+ byte single
+	 * response line) are not read back reliably by the line-based dialog
+	 * parser. Capturing the raw bytes — exactly what `lte test bypass` does —
+	 * avoids that. Entering data-mode before the command is sent guarantees
+	 * the whole response lands in the raw pipe (the line parser never sees it).
+	 */
+	ret = ctr_lte_link_enter_data_mode(dev_lte_if);
+	if (ret) {
+		LOG_ERR("Call `ctr_lte_link_enter_data_mode` failed: %d", ret);
+		return ret;
+	}
+
+	ret = ctr_lte_link_send_data(dev_lte_if, K_SECONDS(1), cmd, strlen(cmd));
+	if (ret == 0) {
+		ret = ctr_lte_link_send_data(dev_lte_if, K_SECONDS(1), "\r\n", 2);
+	}
+	if (ret) {
+		LOG_ERR("Call `ctr_lte_link_send_data` failed: %d", ret);
+		goto exit_data_mode;
+	}
+
+	size_t total = 0;
+	k_timepoint_t end = sys_timepoint_calc(timeout);
+	buf[0] = '\0';
+	while (total < buf_size - 1) {
+		size_t got = 0;
+		ret = ctr_lte_link_recv_data(dev_lte_if, sys_timepoint_timeout(end), buf + total,
+					     buf_size - 1 - total, &got);
+		if (got) {
+			total += got;
+			buf[total] = '\0';
+			/* Stop as soon as the AT response terminator arrives. base64url
+			 * payloads never contain a bare CRLF, so these only match the
+			 * real result line. */
+			if (strstr((char *)buf, "\r\nOK\r\n") ||
+			    strstr((char *)buf, "\r\nERROR") ||
+			    strstr((char *)buf, "\r\n+CME ERROR")) {
+				ret = 0;
+				break;
+			}
+		}
+		if (ret == -EAGAIN || (ret == 0 && got == 0)) {
+			if (sys_timepoint_expired(end)) {
+				ret = -ETIMEDOUT;
+				break;
+			}
+			k_sleep(K_MSEC(1)); /* UART bytes arrive in chunks */
+			continue;
+		}
+		if (ret) {
+			break;
+		}
+	}
+
+exit_data_mode:;
 	int ret2 = ctr_lte_link_exit_data_mode(dev_lte_if);
 	if (ret2) {
 		LOG_ERR("Call `ctr_lte_link_exit_data_mode` failed: %d", ret2);

--- a/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
@@ -11,6 +11,10 @@
 #include "ctr_lte_v2_talk.h"
 #include "ctr_lte_v2_tok.h"
 
+/* Accessor for the consumer registry maintained in ctr_lte_v2.c.
+ * Internal, file-local prototype — not part of the public API. */
+size_t ctr_lte_v2_consumers_get(const struct ctr_lte_v2_consumer *const **out);
+
 /* CHESTER includes */
 #include <chester/ctr_lte_v2.h>
 #include <chester/ctr_rtc.h>
@@ -146,6 +150,27 @@ static void process_urc(const char *line)
 			}
 			ctr_lte_v2_state_set_gnss_update(&update);
 			m_event_delegate_cb(CTR_LTE_V2_EVENT_XGPS);
+		}
+	} else {
+		/* Phase 2: walk registered consumers for any unmatched prefix.
+		 * The existing hard-coded prefixes above take precedence — only
+		 * URCs that fell through every branch reach this loop. First
+		 * match wins. Zero registered consumers ⇒ this loop is empty
+		 * and behaviour is bit-identical to the legacy single-consumer
+		 * layout. */
+		const struct ctr_lte_v2_consumer *const *list;
+		size_t count = ctr_lte_v2_consumers_get(&list);
+		for (size_t i = 0; i < count; i++) {
+			const struct ctr_lte_v2_consumer *c = list[i];
+			if (!c->urc_prefixes || !c->on_urc) {
+				continue;
+			}
+			for (const char *const *p = c->urc_prefixes; *p; p++) {
+				if (!strncmp(line, *p, strlen(*p))) {
+					c->on_urc(line);
+					return;
+				}
+			}
 		}
 	}
 }
@@ -428,12 +453,37 @@ int ctr_lte_v2_flow_prepare(void)
 		return ret;
 	}
 
-	/* TODO Configurable? */
+#if defined(CONFIG_CTR_LTE_V2_IDLE_PROFILE_EDRX_NO_PSM)
+	/* PSM off, eDRX on — required for reachable downlink (Phase 2). */
+	ret = ctr_lte_v2_talk_at_cpsms(&m_talk, (int[]){0}, NULL, NULL);
+	if (ret) {
+		LOG_ERR("Call `ctr_lte_v2_talk_at_cpsms` 0 failed: %d", ret);
+		return ret;
+	}
+	/* AcT type 4 = LTE-M; 5 = NB-IoT. Request appropriate cycle per RAT. */
+	{
+		const char *edrx_cycle;
+		int act_type;
+		if (strstr(g_ctr_lte_v2_config.mode, "lte-m")) {
+			act_type = 4;
+			edrx_cycle = CONFIG_CTR_LTE_V2_EDRX_CYCLE_LTEM;
+		} else {
+			act_type = 5;
+			edrx_cycle = CONFIG_CTR_LTE_V2_EDRX_CYCLE_NBIOT;
+		}
+		ret = ctr_lte_v2_talk_at_cedrxs(&m_talk, 2, act_type, edrx_cycle);
+		if (ret) {
+			LOG_ERR("Call `ctr_lte_v2_talk_at_cedrxs` failed: %d", ret);
+			return ret;
+		}
+	}
+#else  /* CONFIG_CTR_LTE_V2_IDLE_PROFILE_PSM — default, bit-identical to pre-Phase-2 */
 	ret = ctr_lte_v2_talk_at_cpsms(&m_talk, (int[]){1}, "00111000", "00000000");
 	if (ret) {
 		LOG_ERR("Call `ctr_lte_v2_talk_at_cpsms` failed: %d", ret);
 		return ret;
 	}
+#endif
 
 	ret = ctr_lte_v2_talk_at_ceppi(&m_talk, 1);
 	if (ret) {
@@ -1169,6 +1219,54 @@ int ctr_lte_v2_flow_cmd_without_response(const char *s)
 	}
 
 	return 0;
+}
+
+int ctr_lte_v2_consumer_read_raw(uint8_t *buf, size_t len, k_timeout_t timeout)
+{
+	int ret;
+
+	if (!buf || !len) {
+		return -EINVAL;
+	}
+
+	if (!atomic_get(&m_started)) {
+		return -ENOTCONN;
+	}
+
+	/* Switch the link to data-mode for the duration of the read. The link
+	 * driver gates recv_data on in_data_mode; enter/exit_data_mode each
+	 * take the link mutex, so this is safe against concurrent AT dialogs.
+	 *
+	 * NOTE for callers: the line parser does not stop mid-byte. To capture
+	 * bytes that arrive immediately after a URC header (e.g. #XMQTTMSG),
+	 * the consumer's on_urc must call this synchronously *before* returning
+	 * — otherwise subsequent bytes are absorbed by the line parser and
+	 * lost. See `plans/2026-05-28-poc1-phase2-step0.5-consumer-api-proposal.md`
+	 * §5 for the design rationale. */
+	ret = ctr_lte_link_enter_data_mode(dev_lte_if);
+	if (ret) {
+		LOG_ERR("Call `ctr_lte_link_enter_data_mode` failed: %d", ret);
+		return ret;
+	}
+
+	size_t got = 0;
+	ret = ctr_lte_link_recv_data(dev_lte_if, timeout, buf, len, &got);
+	if (ret == 0 && got != len) {
+		ret = -ETIMEDOUT;
+	}
+	if (ret) {
+		LOG_WRN("Call `ctr_lte_link_recv_data` got %u/%u: %d", got, len, ret);
+	}
+
+	int ret2 = ctr_lte_link_exit_data_mode(dev_lte_if);
+	if (ret2) {
+		LOG_ERR("Call `ctr_lte_link_exit_data_mode` failed: %d", ret2);
+		if (!ret) {
+			ret = ret2;
+		}
+	}
+
+	return ret;
 }
 
 int ctr_lte_v2_flow_bypass_set_cb(ctr_lte_v2_flow_bypass_cb cb, void *user_data)

--- a/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
@@ -1238,6 +1238,20 @@ int ctr_lte_v2_consumer_at_cmd(const char *cmd, char *resp_buf, size_t resp_size
 	return ctr_lte_v2_talk_at_cmd(&m_talk, cmd);
 }
 
+int ctr_lte_v2_consumer_mqtt_publish_datamode(const char *topic, int qos, int retain,
+					      const void *buf, size_t len)
+{
+	if (!topic || !buf || !len) {
+		return -EINVAL;
+	}
+
+	if (!atomic_get(&m_started)) {
+		return -ENOTCONN;
+	}
+
+	return ctr_lte_v2_talk_at_xmqttpub_datamode(&m_talk, topic, qos, retain, buf, len);
+}
+
 int ctr_lte_v2_consumer_at_cmd_long(const char *cmd, char *resp_buf, size_t resp_size)
 {
 	if (!cmd || !resp_buf || !resp_size) {

--- a/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_flow.c
@@ -1221,6 +1221,23 @@ int ctr_lte_v2_flow_cmd_without_response(const char *s)
 	return 0;
 }
 
+int ctr_lte_v2_consumer_at_cmd(const char *cmd, char *resp_buf, size_t resp_size)
+{
+	if (!cmd) {
+		return -EINVAL;
+	}
+
+	if (!atomic_get(&m_started)) {
+		return -ENOTCONN;
+	}
+
+	if (resp_buf && resp_size) {
+		resp_buf[0] = '\0';
+		return ctr_lte_v2_talk_at_cmd_with_resp(&m_talk, cmd, resp_buf, resp_size);
+	}
+	return ctr_lte_v2_talk_at_cmd(&m_talk, cmd);
+}
+
 int ctr_lte_v2_consumer_read_raw(uint8_t *buf, size_t len, k_timeout_t timeout)
 {
 	int ret;

--- a/subsys/ctr_lte_v2/ctr_lte_v2_talk.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_talk.c
@@ -580,6 +580,26 @@ int ctr_lte_v2_talk_at_cpsms(struct ctr_lte_v2_talk *talk, int *p1, const char *
 	DIALOG_EPILOG /* clang-format on */
 }
 
+int ctr_lte_v2_talk_at_cedrxs(struct ctr_lte_v2_talk *talk, int mode, int act_type,
+			      const char *cycle)
+{
+	DIALOG_PROLOG /* clang-format off */
+
+	DIALOG_ENTER();
+	if (cycle && cycle[0]) {
+		DIALOG_SEND_LINE("AT+CEDRXS=%d,%d,\"%s\"", mode, act_type, cycle);
+	} else {
+		DIALOG_SEND_LINE("AT+CEDRXS=%d,%d", mode, act_type);
+	}
+	DIALOG_LOOP_RUN(RESPONSE_TIMEOUT_S, {
+		DIALOG_LOOP_ABORT_ON_PFX("ERROR");
+		DIALOG_LOOP_BREAK_ON_STR("OK");
+	});
+	DIALOG_EXIT();
+
+	DIALOG_EPILOG /* clang-format on */
+}
+
 int ctr_lte_v2_talk_at_cscon(struct ctr_lte_v2_talk *talk, int p1)
 {
 	DIALOG_PROLOG /* clang-format off */

--- a/subsys/ctr_lte_v2/ctr_lte_v2_talk.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_talk.c
@@ -941,6 +941,47 @@ int ctr_lte_v2_talk_at_xsend(struct ctr_lte_v2_talk *talk, const void *buf, size
 	DIALOG_EPILOG /* clang-format on */
 }
 
+int ctr_lte_v2_talk_at_xmqttpub_datamode(struct ctr_lte_v2_talk *talk, const char *topic, int qos,
+					 int retain, const void *buf, size_t len)
+{
+	DIALOG_PROLOG /* clang-format off */
+
+	char xdm[16] = {0};
+
+	DIALOG_ENTER();
+	/* Empty <msg> arg ("") makes SLM enter data-mode and take the payload raw.
+	 * A bare ,, (missing token) is rejected by the AT parser, so pass "". */
+	DIALOG_SEND_LINE("AT#XMQTTPUB=\"%s\",\"\",%d,%d", topic, qos, retain);
+	DIALOG_LOOP_RUN(RESPONSE_TIMEOUT_S, {
+		DIALOG_LOOP_ABORT_ON_PFX("ERROR");
+		DIALOG_LOOP_BREAK_ON_STR("OK");
+	});
+	DIALOG_SEND_DATA(buf, len);
+	DIALOG_LOOP_RUN(RESPONSE_TIMEOUT_S, {
+		DIALOG_LOOP_ABORT_ON_PFX("ERROR");
+		DIALOG_LOOP_BREAK_ON_PFX("#XDATAMODE: ", xdm, sizeof(xdm));
+	});
+	DIALOG_SEND_DATA("+++", 3);
+	if (!strlen(xdm)) {
+		DIALOG_ABORT(-EPIPE);
+	}
+	for (size_t i = 0; i < strlen(xdm); i++) {
+		if (!isdigit((int)xdm[i])) {
+			DIALOG_ABORT(-EPIPE);
+		}
+	}
+	if (len != strtol(xdm, NULL, 10)) {
+		DIALOG_ABORT(-EPIPE);
+	}
+	DIALOG_LOOP_RUN(RESPONSE_TIMEOUT_S, {
+		DIALOG_LOOP_ABORT_ON_PFX("ERROR");
+		DIALOG_LOOP_BREAK_ON_STR("#XDATAMODE: 0");
+	});
+	DIALOG_EXIT();
+
+	DIALOG_EPILOG /* clang-format on */
+}
+
 int ctr_lte_v2_talk_at_xsend_string(struct ctr_lte_v2_talk *talk, const void *buf, size_t len)
 {
 	DIALOG_PROLOG /* clang-format off */

--- a/subsys/ctr_lte_v2/ctr_lte_v2_talk.c
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_talk.c
@@ -1252,6 +1252,26 @@ int ctr_lte_v2_talk_at_cmd_with_resp(struct ctr_lte_v2_talk *talk, const char *s
 	DIALOG_EPILOG /* clang-format on */
 }
 
+int ctr_lte_v2_talk_at_cmd_with_resp_long(struct ctr_lte_v2_talk *talk, const char *s, char *buf,
+					  size_t size)
+{
+	DIALOG_PROLOG /* clang-format off */
+
+	DIALOG_ENTER();
+	DIALOG_SEND_LINE("%s", s);
+	DIALOG_LOOP_RUN(RESPONSE_TIMEOUT_L, {
+		DIALOG_LOOP_ABORT_ON_PFX("ERROR");
+		if (!DIALOG_LOOP_GATHER_GET_COUNT()) {
+			DIALOG_LOOP_GATHER(buf, size);
+		} else {
+			DIALOG_LOOP_BREAK_ON_STR("OK");
+		}
+	});
+	DIALOG_EXIT();
+
+	DIALOG_EPILOG /* clang-format on */
+}
+
 int ctr_lte_v2_talk_at_cmd_with_resp_prefix(struct ctr_lte_v2_talk *talk, const char *s, char *buf,
 					    size_t size, const char *pfx)
 {

--- a/subsys/ctr_lte_v2/ctr_lte_v2_talk.h
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_talk.h
@@ -71,6 +71,11 @@ int ctr_lte_v2_talk_at_xsendto(struct ctr_lte_v2_talk *talk, const char *p1, int
 			       const void *buf, size_t len);
 int ctr_lte_v2_talk_at_xsend(struct ctr_lte_v2_talk *talk, const void *buf, size_t len);
 int ctr_lte_v2_talk_at_xsend_string(struct ctr_lte_v2_talk *talk, const void *buf, size_t len);
+/* Publish an MQTT message via SLM data-mode (AT#XMQTTPUB="topic",,qos,retain),
+ * so the payload bytes are sent raw and may contain any byte (incl. ") — the
+ * naive quoted-arg parser of the inline form rejects " with -EILSEQ. */
+int ctr_lte_v2_talk_at_xmqttpub_datamode(struct ctr_lte_v2_talk *talk, const char *topic, int qos,
+					 int retain, const void *buf, size_t len);
 int ctr_lte_v2_talk_at_xrecv(struct ctr_lte_v2_talk *talk, int timeout, char *buf, size_t size,
 			     size_t *len);
 int ctr_lte_v2_talk_at_xsim(struct ctr_lte_v2_talk *talk, int p1);

--- a/subsys/ctr_lte_v2/ctr_lte_v2_talk.h
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_talk.h
@@ -50,6 +50,8 @@ int ctr_lte_v2_talk_at_coneval(struct ctr_lte_v2_talk *talk, char *buf, size_t s
 int ctr_lte_v2_talk_at_cops_q(struct ctr_lte_v2_talk *talk, char *buf, size_t size);
 int ctr_lte_v2_talk_at_cops(struct ctr_lte_v2_talk *talk, int p1, int *p2, const char *p3);
 int ctr_lte_v2_talk_at_cpsms(struct ctr_lte_v2_talk *talk, int *p1, const char *p2, const char *p3);
+int ctr_lte_v2_talk_at_cedrxs(struct ctr_lte_v2_talk *talk, int mode, int act_type,
+			      const char *cycle);
 int ctr_lte_v2_talk_at_cscon(struct ctr_lte_v2_talk *talk, int p1);
 int ctr_lte_v2_talk_at_hwversion(struct ctr_lte_v2_talk *talk, char *buf, size_t size);
 int ctr_lte_v2_talk_at_mdmev(struct ctr_lte_v2_talk *talk, int p1);

--- a/subsys/ctr_lte_v2/ctr_lte_v2_talk.h
+++ b/subsys/ctr_lte_v2/ctr_lte_v2_talk.h
@@ -91,6 +91,8 @@ int ctr_lte_v2_talk_crsm_214(struct ctr_lte_v2_talk *talk);
 int ctr_lte_v2_talk_at_cmd(struct ctr_lte_v2_talk *talk, const char *s);
 int ctr_lte_v2_talk_at_cmd_with_resp(struct ctr_lte_v2_talk *talk, const char *s, char *buf,
 				     size_t size);
+int ctr_lte_v2_talk_at_cmd_with_resp_long(struct ctr_lte_v2_talk *talk, const char *s, char *buf,
+					  size_t size);
 int ctr_lte_v2_talk_at_cmd_with_resp_prefix(struct ctr_lte_v2_talk *talk, const char *s, char *buf,
 					    size_t size, const char *pfx);
 


### PR DESCRIPTION
## Summary

Adds a **multi-consumer** model to `ctr_lte_v2` so an application can drive its
own MQTT session over the SLM modem *alongside* `ctr_cloud`, instead of
`ctr_cloud` being the sole owner of the modem. This is what let us run a second
MQTT session (Azure Event Grid, mutual-TLS) on the nRF9160 concurrently with the
HARDWARIO control plane on a CHESTER-M locker controller.

All changes are confined to `ctr_lte_v2` (plus small `ctr_lte_link` / `ctr_cloud`
touches). 8 files, +734/-4.

## What's included

**Multi-consumer core**
- `ctr_lte_v2: multi-consumer registration + idle profile Kconfig` — register N
  consumers; per-consumer idle/reachability profile.
- `ctr_lte_v2: expose ctr_lte_v2_consumer_at_cmd for consumer-side AT injection` —
  a consumer can issue AT commands (e.g. `AT#XMQTT*`) without racing `ctr_cloud`.
- `ctr_lte_v2: add on_prepare consumer hook + 2 KB TX line buffer` — a consumer
  gets a CFUN=0/4 "prepare" window (needed for `AT%CMNG`/`AT%KEYGEN`
  provisioning); TX line buffer widened to 2 KB for large PEM/key writes.
- `ctr_lte_v2: raw + long-timeout consumer AT paths; CFUN=4 provisioning window`.

**Consumer read robustness**
- `ctr_lte_v2: consumer_read_raw — loop on partial reads`.
- `ctr_lte_v2: drop dangling plan reference in consumer_read_raw comment` (cleanup).

**MQTT publish**
- `ctr_lte_v2: SLM data-mode MQTT publish for arbitrary payloads` — publish via
  SLM data-mode so payloads containing `"`/binary aren't mangled by the quoted
  `AT#XMQTTPUB` argument parser (the inline path truncates on the first embedded
  quote → `-EILSEQ`). Mirrors the `AT#XSEND` data-mode dance.

**Power / reachability**
- `ctr_lte_v2: extend keep_modem_reachable to the XMODEMSLEEP path`.

**Bugfix**
- `Fix downlink RAI releasing connection during multi-fragment transfers` — RAI
  was signalling "no further data" mid-transfer, dropping the connection before a
  multi-fragment downlink completed.

## Validation

Exercised end-to-end on real hardware (nRF9160 + SLM, CHESTER-M): a second MQTT
consumer connects to Azure Event Grid (mTLS), publishes JSON/binary app-plane
messages via data-mode, and receives downlinks — concurrently with `ctr_cloud`
on the HARDWARIO control plane. Most recently used to drive a full application
round-trip (uplink → cloud response → downlink) on-device.

## Notes for reviewers

- The consumer API is additive; single-consumer (`ctr_cloud`-only) behaviour is
  unchanged when no extra consumer registers.
- Happy to split this into smaller PRs (e.g. the RAI fix and the data-mode
  publish stand alone) if that's easier to review.
